### PR TITLE
Feature/hash constructors

### DIFF
--- a/outreach_gem/lib/outreach-s3/ruby-upload-s3.rb
+++ b/outreach_gem/lib/outreach-s3/ruby-upload-s3.rb
@@ -12,12 +12,12 @@ class OutreachUploadS3
     # )
 
     def initialize(parameters)
-        if parameters.fetch(:secretKey, nil).nil?
-            raise 'secretKey cannot be empty'
-        end
-
         if parameters.fetch(:key, nil).nil?
             raise 'key cannot be empty'
+        end
+        
+        if parameters.fetch(:secretKey, nil).nil?
+            raise 'secretKey cannot be empty'
         end
 
         if parameters.fetch(:region, nil).nil?

--- a/outreach_gem/lib/outreach-s3/ruby-upload-s3.rb
+++ b/outreach_gem/lib/outreach-s3/ruby-upload-s3.rb
@@ -2,36 +2,42 @@ require 'aws-sdk-s3'
 
 class OutreachUploadS3
 
-    # @param key [String] Name of the key used to access AWS
-    # @param secret [String] Name of the secret key used to access AWS
-    # @param region [String] Name of the region of the bucket
-    # @param bucketName [String] Name of the S3 Bucket
-    def initialize(key, secretKey, region, bucketName)
-        if secretKey.empty?
+    # @param parameters Is an object that represents the parameters for the initialization of this component 
+    # example of input format: 
+    # outreachClient = OutreachUploadS3.new(
+    #     key: ENV['S3_ACCESS_KEY'], [String] Name of the key used to access AWS
+    #     secretKey: ENV['S3_SECRET_KEY'], [String] Name of the secret key used to access AWS
+    #     region: 'us-west-2', [String] Name of the region of the bucket
+    #     bucketName: 'fb3e8922-fcb9-4042-b9f3-3f041602b5d3' [String] Name of the S3 Bucket
+    # )
+
+    def initialize(parameters)
+        if parameters.fetch(:secretKey, nil).nil?
             raise 'secretKey cannot be empty'
         end
 
-        if key.empty?
+        if parameters.fetch(:key, nil).nil?
             raise 'key cannot be empty'
         end
 
-        if region.empty?
+        if parameters.fetch(:region, nil).nil?
             raise 'region cannot be empty'
         end
 
-        if bucketName.empty?
+        if parameters.fetch(:bucketName, nil).nil?
             raise 'bucketName cannot be empty'
         end
-        @region = region
-        @bucketName = bucketName
+
+        @region = parameters.fetch(:region)
+        @bucketName = parameters.fetch(:bucketName)
        
         Aws.config.update({
-            credentials: Aws::Credentials.new(key, secretKey)
+            credentials: Aws::Credentials.new(parameters.fetch(:key), parameters.fetch(:secretKey))
         })
         @s3_client = Aws::S3::Client.new({
             region:            @region,
-            access_key_id:     key,
-            secret_access_key: secretKey
+            access_key_id:     parameters.fetch(:key),
+            secret_access_key: parameters.fetch(:secretKey)
         })
     end
 

--- a/outreach_gem/lib/rest-client/restfulclient.rb
+++ b/outreach_gem/lib/rest-client/restfulclient.rb
@@ -7,35 +7,58 @@ require_relative 'resttype'
 class RestClient
 
     # Initalize the object to perform the operations
-    # @param uri [String] The URL to perform the request against
-    # @param headers [Hash] Object that resembles the following structure
-    # {
-    #    'Content-Type' => 'application/json'
-    # }
-    # @param rest_type [resttype] Module that defines the type of operation that we are about to perform
-    # @param ssl [Boolean] True -> SSL is enabled. False -> SSL is disabled
-    # @param params [Hash] Is an object that represents the query string parameters to assign to the URL within the give
+    # @param parameters [Hash] Is an object that represents the parameters for the initialization of this component
     # restful invocation {'state' => 'started'}
-    def initialize(uri, headers, rest_type, ssl, params)
-        @uri = URI(uri)
+    # example of input format: 
+    # RestClient.new(
+    # uri: 'https://api.travis-ci.com/repo/AES-Outreach%2FForms-Application/builds',  ([String] The URL to perform the request against)
+    # headers: { [Hash] Object that resembles the following structure
+    #     'Content-Type' => 'application/json'
+    # },
+    # rest_type: RestTypes::GET, [resttype] Module that defines the type of operation that we are about to perform
+    # ssl: true, [Boolean] True -> SSL is enabled. False -> SSL is disabled
+    # params:  {'state' => 'started'} [Hash] Is an object that represents the query string parameters to assign to the URL within the give
+    # )
+
+
+    def initialize(parameters)
+        
+        if parameters.fetch(:uri, nil).nil?
+            raise 'uri cannot be empty'
+        end
+
+        if parameters.fetch(:headers, nil).nil?
+            raise 'headers cannot be empty'
+        end
+
+        if parameters.fetch(:rest_type, nil).nil?
+            raise 'rest_type cannot be empty'
+        end
+        
+        if parameters.fetch(:ssl, nil).nil?
+            raise 'ssl cannot be empty'
+        end
+
+
+        @uri = URI(parameters.fetch(:uri))
         @http = Net::HTTP.new(@uri.host, @uri.port)
 
-        if ssl === true
+        if parameters.fetch(:ssl) === true
             @http.use_ssl = true
         end
         
-        if params.nil?
-            if RestTypes::POST === rest_type
-                @req = Net::HTTP::Post.new(@uri.path, headers)
-            elsif  RestTypes::GET === rest_type
-                @req = Net::HTTP::Get.new(@uri.path, headers)
+        if parameters.fetch(:params).nil?
+            if RestTypes::POST === parameters.fetch(:rest_type)
+                @req = Net::HTTP::Post.new(@uri.path, parameters.fetch(:headers))
+            elsif  RestTypes::GET === parameters.fetch(:rest_type)
+                @req = Net::HTTP::Get.new(@uri.path, parameters.fetch(:headers))
             end
         else
-            @uri.query = URI.encode_www_form( params )
-            if RestTypes::POST === rest_type
-                @req = Net::HTTP::Post.new(@uri.path + '?' + @uri.query, headers)
-            elsif  RestTypes::GET === rest_type
-                @req = Net::HTTP::Get.new(@uri.path + '?' + @uri.query, headers)
+            @uri.query = URI.encode_www_form(parameters.fetch(:params))
+            if RestTypes::POST === parameters.fetch(:rest_type)
+                @req = Net::HTTP::Post.new(@uri.path + '?' + @uri.query, parameters.fetch(:headers))
+            elsif  RestTypes::GET === parameters.fetch(:rest_type)
+                @req = Net::HTTP::Get.new(@uri.path + '?' + @uri.query, parameters.fetch(:headers))
             end
         end
         

--- a/outreach_gem/lib/rest-client/restfulclient.rb
+++ b/outreach_gem/lib/rest-client/restfulclient.rb
@@ -47,7 +47,7 @@ class RestClient
             @http.use_ssl = true
         end
         
-        if parameters.fetch(:params).nil?
+        if parameters.fetch(:params, nil).nil?
             if RestTypes::POST === parameters.fetch(:rest_type)
                 @req = Net::HTTP::Post.new(@uri.path, parameters.fetch(:headers))
             elsif  RestTypes::GET === parameters.fetch(:rest_type)

--- a/outreach_gem/tests/outreach-s3/unit-tests.rb
+++ b/outreach_gem/tests/outreach-s3/unit-tests.rb
@@ -115,5 +115,16 @@ class TestRestClient < Test::Unit::TestCase
         }
         assert_equal("bucketName cannot be empty", exception.message) 
     end
+
+    def test_upload_s3_other_order_initialization() 
+        assert_nothing_raised do
+            outreachClient = OutreachUploadS3.new(
+                :region => 'us-west-2',
+                :key => ENV['S3_ACCESS_KEY'], 
+                :bucketName => 'fb3e8922-fcb9-4042-b9f3-3f041602b5d3',
+                :secretKey => ENV['S3_SECRET_KEY']
+            )
+        end
+    end
         
 end

--- a/outreach_gem/tests/outreach-s3/unit-tests.rb
+++ b/outreach_gem/tests/outreach-s3/unit-tests.rb
@@ -3,18 +3,22 @@ require "test/unit"
 
 class TestRestClient < Test::Unit::TestCase
     def test_connection()
-        OutreachUploadS3.new(ENV['S3_ACCESS_KEY'], 
-            ENV['S3_SECRET_KEY'], 
-            'us-west-2', 
-            'fb3e8922-fcb9-4042-b9f3-3f041602b5d3')
+        OutreachUploadS3.new(
+            key: ENV['S3_ACCESS_KEY'], 
+            secretKey: ENV['S3_SECRET_KEY'], 
+            region: 'us-west-2', 
+            bucketName: 'fb3e8922-fcb9-4042-b9f3-3f041602b5d3'
+        )
     end
 
     def test_connection_with_uploada_and_download_in_ram()
         # Get a connection to the bucket
-        outreachClient = OutreachUploadS3.new(ENV['S3_ACCESS_KEY'], 
-            ENV['S3_SECRET_KEY'], 
-            'us-west-2', 
-            'fb3e8922-fcb9-4042-b9f3-3f041602b5d3')
+        outreachClient = OutreachUploadS3.new(
+            key: ENV['S3_ACCESS_KEY'], 
+            secretKey: ENV['S3_SECRET_KEY'], 
+            region: 'us-west-2', 
+            bucketName: 'fb3e8922-fcb9-4042-b9f3-3f041602b5d3'
+        )
 
         # Upload a file
         result = outreachClient.uploadFile('./5dceb1e7-d638-4f3e-81ef-321a282fe8bc.binary', '5dceb1e7-d638-4f3e-81ef-321a282fe8bc.binary')
@@ -34,10 +38,12 @@ class TestRestClient < Test::Unit::TestCase
 
     def test_connection_with_uploada_and_download_on_disk()
         # Get a connection to the bucket
-        outreachClient = OutreachUploadS3.new(ENV['S3_ACCESS_KEY'], 
-            ENV['S3_SECRET_KEY'], 
-            'us-west-2', 
-            'fb3e8922-fcb9-4042-b9f3-3f041602b5d3')
+        outreachClient = OutreachUploadS3.new(
+            key: ENV['S3_ACCESS_KEY'], 
+            secretKey: ENV['S3_SECRET_KEY'], 
+            region: 'us-west-2', 
+            bucketName: 'fb3e8922-fcb9-4042-b9f3-3f041602b5d3'
+        )
 
         # Upload a file
         result = outreachClient.uploadFile('./5dceb1e7-d638-4f3e-81ef-321a282fe8bc.binary', '5dceb1e7-d638-4f3e-81ef-321a282fe8bc.binary')
@@ -55,11 +61,58 @@ class TestRestClient < Test::Unit::TestCase
 
     def test_delete_bucket()
         # Get a connection to the bucket
-        outreachClient = OutreachUploadS3.new(ENV['S3_ACCESS_KEY'], 
-            ENV['S3_SECRET_KEY'], 
-            'us-west-2', 
-            'fb3e8922-fcb9-4042-b9f3-3f041602b5d3')
+        outreachClient = OutreachUploadS3.new(
+            key: ENV['S3_ACCESS_KEY'], 
+            secretKey: ENV['S3_SECRET_KEY'], 
+            region: 'us-west-2', 
+            bucketName: 'fb3e8922-fcb9-4042-b9f3-3f041602b5d3'
+        )
         outreachClient.clearBucket()
         result = outreachClient.uploadFile('./5dceb1e7-d638-4f3e-81ef-321a282fe8bc.binary', 'uOttawa/5dceb1e7-d638-4f3e-81ef-321a282fe8bc.binary')
     end
+
+    def test_upload_s3_key_not_nil() 
+        exception = assert_raise() {
+            outreachClient = OutreachUploadS3.new(
+                secretKey: ENV['S3_SECRET_KEY'], 
+                region: 'us-west-2', 
+               bucketName: 'fb3e8922-fcb9-4042-b9f3-3f041602b5d3'
+            )
+        }
+        assert_equal("key cannot be empty", exception.message) 
+    end
+
+    def test_upload_s3_secretKey_not_nil() 
+        exception = assert_raise() {
+            outreachClient = OutreachUploadS3.new(
+                key: ENV['S3_ACCESS_KEY'], 
+                region: 'us-west-2', 
+               bucketName: 'fb3e8922-fcb9-4042-b9f3-3f041602b5d3'
+            )
+        }
+        assert_equal("secretKey cannot be empty", exception.message) 
+    end
+
+    def test_upload_s3_region_not_nil() 
+        exception = assert_raise() {
+            outreachClient = OutreachUploadS3.new(
+                key: ENV['S3_ACCESS_KEY'], 
+                secretKey: ENV['S3_SECRET_KEY'], 
+               bucketName: 'fb3e8922-fcb9-4042-b9f3-3f041602b5d3'
+            )
+        }
+        assert_equal("region cannot be empty", exception.message) 
+    end
+
+    def test_upload_s3_bucketName_not_nil() 
+        exception = assert_raise() {
+            outreachClient = OutreachUploadS3.new(
+                key: ENV['S3_ACCESS_KEY'], 
+                secretKey: ENV['S3_SECRET_KEY'], 
+                region: 'us-west-2'
+            )
+        }
+        assert_equal("bucketName cannot be empty", exception.message) 
+    end
+        
 end

--- a/outreach_gem/tests/outreach-s3/unit-tests.rb
+++ b/outreach_gem/tests/outreach-s3/unit-tests.rb
@@ -4,10 +4,10 @@ require "test/unit"
 class TestRestClient < Test::Unit::TestCase
     def test_connection()
         OutreachUploadS3.new(
-            key: ENV['S3_ACCESS_KEY'], 
-            secretKey: ENV['S3_SECRET_KEY'], 
-            region: 'us-west-2', 
-            bucketName: 'fb3e8922-fcb9-4042-b9f3-3f041602b5d3'
+            :key => ENV['S3_ACCESS_KEY'], 
+            :secretKey => ENV['S3_SECRET_KEY'], 
+            :region => 'us-west-2', 
+            :bucketName => 'fb3e8922-fcb9-4042-b9f3-3f041602b5d3'
         )
     end
 
@@ -15,10 +15,10 @@ class TestRestClient < Test::Unit::TestCase
         # Get a connection to the bucket
 
         outreachClient = OutreachUploadS3.new(
-            key: ENV['S3_ACCESS_KEY'], 
-            secretKey: ENV['S3_SECRET_KEY'], 
-            region: 'us-west-2', 
-            bucketName: 'fb3e8922-fcb9-4042-b9f3-3f041602b5d3'
+            :key => ENV['S3_ACCESS_KEY'], 
+            :secretKey => ENV['S3_SECRET_KEY'], 
+            :region => 'us-west-2', 
+            :bucketName => 'fb3e8922-fcb9-4042-b9f3-3f041602b5d3'
         )
 
         # Upload a file
@@ -40,10 +40,10 @@ class TestRestClient < Test::Unit::TestCase
     def test_connection_with_uploada_and_download_on_disk()
         # Get a connection to the bucket
         outreachClient = OutreachUploadS3.new(
-            key: ENV['S3_ACCESS_KEY'], 
-            secretKey: ENV['S3_SECRET_KEY'], 
-            region: 'us-west-2', 
-            bucketName: 'fb3e8922-fcb9-4042-b9f3-3f041602b5d3'
+            :key => ENV['S3_ACCESS_KEY'], 
+            :secretKey => ENV['S3_SECRET_KEY'], 
+            :region => 'us-west-2', 
+            :bucketName => 'fb3e8922-fcb9-4042-b9f3-3f041602b5d3'
         )
 
         # Upload a file
@@ -63,10 +63,10 @@ class TestRestClient < Test::Unit::TestCase
     def test_delete_bucket()
         # Get a connection to the bucket
         outreachClient = OutreachUploadS3.new(
-            key: ENV['S3_ACCESS_KEY'], 
-            secretKey: ENV['S3_SECRET_KEY'], 
-            region: 'us-west-2', 
-            bucketName: 'fb3e8922-fcb9-4042-b9f3-3f041602b5d3'
+            :key => ENV['S3_ACCESS_KEY'], 
+            :secretKey => ENV['S3_SECRET_KEY'], 
+            :region => 'us-west-2', 
+            :bucketName => 'fb3e8922-fcb9-4042-b9f3-3f041602b5d3'
         )
         outreachClient.clearBucket()
         result = outreachClient.uploadFile('./5dceb1e7-d638-4f3e-81ef-321a282fe8bc.binary', 'uOttawa/5dceb1e7-d638-4f3e-81ef-321a282fe8bc.binary')
@@ -75,9 +75,9 @@ class TestRestClient < Test::Unit::TestCase
     def test_upload_s3_key_not_nil() 
         exception = assert_raise() {
             outreachClient = OutreachUploadS3.new(
-                secretKey: ENV['S3_SECRET_KEY'], 
-                region: 'us-west-2', 
-               bucketName: 'fb3e8922-fcb9-4042-b9f3-3f041602b5d3'
+                :secretKey => ENV['S3_SECRET_KEY'], 
+                :region => 'us-west-2', 
+                :bucketName => 'fb3e8922-fcb9-4042-b9f3-3f041602b5d3'
             )
         }
         assert_equal("key cannot be empty", exception.message) 
@@ -86,9 +86,9 @@ class TestRestClient < Test::Unit::TestCase
     def test_upload_s3_secretKey_not_nil() 
         exception = assert_raise() {
             outreachClient = OutreachUploadS3.new(
-                key: ENV['S3_ACCESS_KEY'], 
-                region: 'us-west-2', 
-               bucketName: 'fb3e8922-fcb9-4042-b9f3-3f041602b5d3'
+                :key => ENV['S3_ACCESS_KEY'], 
+                :region => 'us-west-2', 
+                :bucketName => 'fb3e8922-fcb9-4042-b9f3-3f041602b5d3'
             )
         }
         assert_equal("secretKey cannot be empty", exception.message) 
@@ -97,9 +97,9 @@ class TestRestClient < Test::Unit::TestCase
     def test_upload_s3_region_not_nil() 
         exception = assert_raise() {
             outreachClient = OutreachUploadS3.new(
-                key: ENV['S3_ACCESS_KEY'], 
-                secretKey: ENV['S3_SECRET_KEY'], 
-               bucketName: 'fb3e8922-fcb9-4042-b9f3-3f041602b5d3'
+                :key => ENV['S3_ACCESS_KEY'], 
+                :secretKey => ENV['S3_SECRET_KEY'], 
+                :bucketName => 'fb3e8922-fcb9-4042-b9f3-3f041602b5d3'
             )
         }
         assert_equal("region cannot be empty", exception.message) 
@@ -108,9 +108,9 @@ class TestRestClient < Test::Unit::TestCase
     def test_upload_s3_bucketName_not_nil() 
         exception = assert_raise() {
             outreachClient = OutreachUploadS3.new(
-                key: ENV['S3_ACCESS_KEY'], 
-                secretKey: ENV['S3_SECRET_KEY'], 
-                region: 'us-west-2'
+                :key => ENV['S3_ACCESS_KEY'], 
+                :secretKey => ENV['S3_SECRET_KEY'], 
+                :region => 'us-west-2'
             )
         }
         assert_equal("bucketName cannot be empty", exception.message) 

--- a/outreach_gem/tests/outreach-s3/unit-tests.rb
+++ b/outreach_gem/tests/outreach-s3/unit-tests.rb
@@ -13,6 +13,7 @@ class TestRestClient < Test::Unit::TestCase
 
     def test_connection_with_uploada_and_download_in_ram()
         # Get a connection to the bucket
+
         outreachClient = OutreachUploadS3.new(
             key: ENV['S3_ACCESS_KEY'], 
             secretKey: ENV['S3_SECRET_KEY'], 

--- a/outreach_gem/tests/rest-client/unit-tests.rb
+++ b/outreach_gem/tests/rest-client/unit-tests.rb
@@ -6,26 +6,26 @@ class TestRestClient < Test::Unit::TestCase
 
     def test_setURI_1()
         restclient = RestClient.new(
-            uri: 'https://stackoverflow.com/questions/2024805/ruby-send-json-request', 
-            headers: {
+            :uri => 'https://stackoverflow.com/questions/2024805/ruby-send-json-request', 
+            :headers => {
                 'Content-Type' => 'application/json'
                 }, 
-            rest_type: RestTypes::POST, 
-            ssl: false, 
-            params: nil
+            :rest_type => RestTypes::POST, 
+            :ssl => false, 
+            :params => nil
             )
         assert_equal(restclient.getURI(), 'https://stackoverflow.com/questions/2024805/ruby-send-json-request')
     end
 
     def test_setURI_with_query_params()
         restclient = RestClient.new(
-            uri: 'https://stackoverflow.com/questions/2024805/ruby-send-json-request', 
-            headers: {
+            :uri => 'https://stackoverflow.com/questions/2024805/ruby-send-json-request', 
+            :headers => {
                 'Content-Type' => 'application/json'
                 }, 
-            rest_type: RestTypes::POST, 
-            ssl: false, 
-            params: {'state' => 'started'}
+            :rest_type => RestTypes::POST, 
+            :ssl => false, 
+            :params => {'state' => 'started'}
             )
 
         assert_equal(restclient.getURI(), 'https://stackoverflow.com/questions/2024805/ruby-send-json-request?state=started')
@@ -33,13 +33,13 @@ class TestRestClient < Test::Unit::TestCase
 
     def test_setURI_with_multi_query_params()
         restclient = RestClient.new(
-            uri: 'https://stackoverflow.com/questions/2024805/ruby-send-json-request', 
-            headers: {
+            :uri => 'https://stackoverflow.com/questions/2024805/ruby-send-json-request', 
+            :headers => {
                 'Content-Type' => 'application/json'
                 }, 
-            rest_type: RestTypes::POST, 
-            ssl: false, 
-            params: {'state' => 'started', 'another_state' => 'another_start'}
+            :rest_type => RestTypes::POST, 
+            :ssl => false, 
+            :params => {'state' => 'started', 'another_state' => 'another_start'}
             )
 
         assert_equal(restclient.getURI(), 'https://stackoverflow.com/questions/2024805/ruby-send-json-request?state=started&another_state=another_start')
@@ -47,13 +47,13 @@ class TestRestClient < Test::Unit::TestCase
 
     def test_setURI_with_escaped_query_params()
         restclient = RestClient.new(
-            uri: 'https://stackoverflow.com/questions/2024805/ruby-send-json-request', 
-            headers: {
+            :uri => 'https://stackoverflow.com/questions/2024805/ruby-send-json-request', 
+            :headers => {
                 'Content-Type' => 'application/json'
                 }, 
-            rest_type: RestTypes::POST, 
-            ssl: false, 
-            params: {'state' => 'AES-Outreach/Forms-Application'}
+            :rest_type => RestTypes::POST, 
+            :ssl => false, 
+            :params => {'state' => 'AES-Outreach/Forms-Application'}
             )
 
         assert_equal(restclient.getURI(), 'https://stackoverflow.com/questions/2024805/ruby-send-json-request?state=AES-Outreach%2FForms-Application')
@@ -61,63 +61,63 @@ class TestRestClient < Test::Unit::TestCase
 
     def test_setURI_2()
         restclient_1 = RestClient.new(
-            uri: 'https://stackoverflow.com/questions/2024805/ruby-send-json-request', 
-            headers: {
+            :uri => 'https://stackoverflow.com/questions/2024805/ruby-send-json-request', 
+            :headers => {
                 'Content-Type' => 'application/json'
                 }, 
-            rest_type: RestTypes::POST, 
-            ssl: false, 
-            params: nil
+            :rest_type => RestTypes::POST, 
+            :ssl => false, 
+            :params => nil
             )
         assert_equal(restclient_1.getURI(), 'https://stackoverflow.com/questions/2024805/ruby-send-json-request')
 
         restclient_2 = RestClient.new(
-            uri: 'https://stackoverflow.com/questions/2024805/ruby-send-json-request2', 
-            headers: {
+            :uri => 'https://stackoverflow.com/questions/2024805/ruby-send-json-request2', 
+            :headers => {
                 'Content-Type' => 'application/json'
                 }, 
-            rest_type: RestTypes::POST, 
-            ssl: false, 
-            params: nil
+            :rest_type => RestTypes::POST, 
+            :ssl => false, 
+            :params => nil
             )
         assert_equal(restclient_2.getURI(), 'https://stackoverflow.com/questions/2024805/ruby-send-json-request2')
     end
 
     def test_get_port()
         restclient = RestClient.new(
-            uri: 'https://stackoverflow.com/questions/2024805/ruby-send-json-request', 
-            headers: {
+            :uri => 'https://stackoverflow.com/questions/2024805/ruby-send-json-request', 
+            :headers => {
                 'Content-Type' => 'application/json'
                 }, 
-            rest_type: RestTypes::POST, 
-            ssl: false, 
-            params: nil
+            :rest_type => RestTypes::POST, 
+            :ssl => false, 
+            :params => nil
             )
         assert_equal(restclient.getPort(), 443)
     end
 
     def test_get_host()
         restclient = RestClient.new(
-            uri: 'https://stackoverflow.com/questions/2024805/ruby-send-json-request', 
-            headers: {
+            :uri => 'https://stackoverflow.com/questions/2024805/ruby-send-json-request', 
+            :headers => {
                 'Content-Type' => 'application/json'
                 }, 
-            rest_type: RestTypes::POST, 
-            ssl: false, 
-            params: nil
+            :rest_type => RestTypes::POST, 
+            :ssl => false, 
+            :params => nil
             )
         assert_equal(restclient.getHost(), 'stackoverflow.com')
     end
 
     def test_set_body()
         restclient = RestClient.new(
-            uri: 'https://stackoverflow.com/questions/2024805/ruby-send-json-request', 
-            headers: {
+            :uri => 'https://stackoverflow.com/questions/2024805/ruby-send-json-request', 
+            :headers => {
                 'Content-Type' => 'application/json'
                 }, 
-            rest_type: RestTypes::POST, 
-            ssl: false, 
-            params: nil
+            :rest_type => RestTypes::POST, 
+            :ssl => false, 
+            :params => nil
             )
 
         restclient.setBody(
@@ -129,15 +129,15 @@ class TestRestClient < Test::Unit::TestCase
     def test_get()
 
         restclient = RestClient.new(
-            uri: 'https://api.travis-ci.com/builds', 
-            headers: {
+            :uri => 'https://api.travis-ci.com/builds', 
+            :headers => {
                 'Content-Type' => 'application/json',
                 'Travis-API-Version' => '3',
                 'Authorization' => "token #{ENV['TRAVIS_TOKEN']}"
             },
-            rest_type: RestTypes::GET, 
-            ssl: true, 
-            params: nil
+            :rest_type => RestTypes::GET, 
+            :ssl => true, 
+            :params => nil
             )
         response = restclient.get()
 
@@ -147,15 +147,15 @@ class TestRestClient < Test::Unit::TestCase
 
     def test_get2()
         restclient = RestClient.new(
-            uri: 'https://api.travis-ci.com/repo/AES-Outreach%2FForms-Application/builds', 
-            headers: {
+            :uri => 'https://api.travis-ci.com/repo/AES-Outreach%2FForms-Application/builds', 
+            :headers => {
                 'Content-Type' => 'application/json',
                 'Travis-API-Version' => '3',
                 'Authorization' => "token #{ENV['TRAVIS_TOKEN']}"
             },
-            rest_type: RestTypes::GET, 
-            ssl: true, 
-            params:  {'state' => 'started'}
+            :rest_type => RestTypes::GET, 
+            :ssl => true, 
+            :params =>  {'state' => 'started'}
             )
 
         response =  restclient.get()
@@ -171,16 +171,16 @@ class TestRestClient < Test::Unit::TestCase
     def test_trigger_travis_build()
 
         restclient = RestClient.new(
-            uri: 'https://api.travis-ci.com/repo/AES-Outreach%2FWebconsole-Branding/requests', 
-            headers: {
+            :uri => 'https://api.travis-ci.com/repo/AES-Outreach%2FWebconsole-Branding/requests', 
+            :headers => {
                 'Content-Type' => 'application/json',
                 'Accept' => 'application/json',
                 'Travis-API-Version' => '3',
                 'Authorization' => "token #{ENV['TRAVIS_TOKEN']}"
             },
-            rest_type: RestTypes::POST, 
-            ssl: true, 
-            params:  nil
+            :rest_type => RestTypes::POST, 
+            :ssl => true, 
+            :params =>  nil
             )
         restclient.setBody({
             "request": {

--- a/outreach_gem/tests/rest-client/unit-tests.rb
+++ b/outreach_gem/tests/rest-client/unit-tests.rb
@@ -199,4 +199,87 @@ class TestRestClient < Test::Unit::TestCase
         assert_not_nil(response)
         assert_equal(response.code, "202")
     end
+
+    def test_uri_not_nil() 
+        exception = assert_raise() {
+            RestClient.new(
+            :headers => {
+                'Content-Type' => 'application/json',
+            },
+            :rest_type => RestTypes::POST, 
+            :ssl => true, 
+            :params =>  nil
+            )
+        }
+        assert_equal("uri cannot be empty", exception.message) 
+    end
+
+    def test_headers_not_nil() 
+        exception = assert_raise() {
+            RestClient.new(
+            :uri => 'https://stackoverflow.com/questions/2024805/ruby-send-json-request',
+            :rest_type => RestTypes::POST, 
+            :ssl => true, 
+            :params =>  nil
+            )
+        }
+        assert_equal("headers cannot be empty", exception.message) 
+    end
+
+    def test_rest_type_not_nil() 
+        exception = assert_raise() {
+            RestClient.new(
+            :uri => 'https://stackoverflow.com/questions/2024805/ruby-send-json-request',
+            :headers => {
+                'Content-Type' => 'application/json',
+            },
+            :ssl => true, 
+            :params =>  nil
+            )
+        }
+        assert_equal("rest_type cannot be empty", exception.message) 
+    end
+
+    def test_ssl_not_nil() 
+        exception = assert_raise() {
+            RestClient.new(
+            :uri => 'https://stackoverflow.com/questions/2024805/ruby-send-json-request',
+            :headers => {
+                'Content-Type' => 'application/json',
+            },
+            :rest_type => RestTypes::POST, 
+            :params =>  nil
+            )
+        }
+        assert_equal("ssl cannot be empty", exception.message) 
+    end
+
+    def test_params_can_be_nil() 
+        assert_nothing_raised do
+            RestClient.new(
+            :uri => 'https://stackoverflow.com/questions/2024805/ruby-send-json-request',
+            :headers => {
+                'Content-Type' => 'application/json',
+            },
+            :rest_type => RestTypes::POST, 
+            :ssl => true
+            )
+        end
+    end
+
+    def test_other_order_initialization() 
+        assert_nothing_raised do
+            RestClient.new(
+            :params =>  nil,
+            :headers => {
+                'Content-Type' => 'application/json',
+            },
+            :uri => 'https://stackoverflow.com/questions/2024805/ruby-send-json-request',
+            :ssl => true, 
+            :rest_type => RestTypes::POST, 
+            )
+        end
+    end
+
+
 end

--- a/outreach_gem/tests/rest-client/unit-tests.rb
+++ b/outreach_gem/tests/rest-client/unit-tests.rb
@@ -5,66 +5,120 @@ require "test/unit"
 class TestRestClient < Test::Unit::TestCase
 
     def test_setURI_1()
-        restclient = RestClient.new('https://stackoverflow.com/questions/2024805/ruby-send-json-request', {
-            'Content-Type' => 'application/json'
-        }, RestTypes::POST, false, nil)
+        restclient = RestClient.new(
+            uri: 'https://stackoverflow.com/questions/2024805/ruby-send-json-request', 
+            headers: {
+                'Content-Type' => 'application/json'
+                }, 
+            rest_type: RestTypes::POST, 
+            ssl: false, 
+            params: nil
+            )
         assert_equal(restclient.getURI(), 'https://stackoverflow.com/questions/2024805/ruby-send-json-request')
     end
 
     def test_setURI_with_query_params()
-        restclient = RestClient.new('https://stackoverflow.com/questions/2024805/ruby-send-json-request', {
-            'Content-Type' => 'application/json'
-        }, RestTypes::POST, false, {'state' => 'started'})
+        restclient = RestClient.new(
+            uri: 'https://stackoverflow.com/questions/2024805/ruby-send-json-request', 
+            headers: {
+                'Content-Type' => 'application/json'
+                }, 
+            rest_type: RestTypes::POST, 
+            ssl: false, 
+            params: {'state' => 'started'}
+            )
 
         assert_equal(restclient.getURI(), 'https://stackoverflow.com/questions/2024805/ruby-send-json-request?state=started')
     end
 
     def test_setURI_with_multi_query_params()
-        restclient = RestClient.new('https://stackoverflow.com/questions/2024805/ruby-send-json-request', {
-            'Content-Type' => 'application/json'
-        }, RestTypes::POST, false, {'state' => 'started', 'another_state' => 'another_start'})
+        restclient = RestClient.new(
+            uri: 'https://stackoverflow.com/questions/2024805/ruby-send-json-request', 
+            headers: {
+                'Content-Type' => 'application/json'
+                }, 
+            rest_type: RestTypes::POST, 
+            ssl: false, 
+            params: {'state' => 'started', 'another_state' => 'another_start'}
+            )
 
         assert_equal(restclient.getURI(), 'https://stackoverflow.com/questions/2024805/ruby-send-json-request?state=started&another_state=another_start')
     end
 
     def test_setURI_with_escaped_query_params()
-        restclient = RestClient.new('https://stackoverflow.com/questions/2024805/ruby-send-json-request', {
-            'Content-Type' => 'application/json'
-        }, RestTypes::POST, false, {'state' => 'AES-Outreach/Forms-Application'})
+        restclient = RestClient.new(
+            uri: 'https://stackoverflow.com/questions/2024805/ruby-send-json-request', 
+            headers: {
+                'Content-Type' => 'application/json'
+                }, 
+            rest_type: RestTypes::POST, 
+            ssl: false, 
+            params: {'state' => 'AES-Outreach/Forms-Application'}
+            )
 
         assert_equal(restclient.getURI(), 'https://stackoverflow.com/questions/2024805/ruby-send-json-request?state=AES-Outreach%2FForms-Application')
     end
 
     def test_setURI_2()
-        restclient_1 = RestClient.new('https://stackoverflow.com/questions/2024805/ruby-send-json-request', {
-            'Content-Type' => 'application/json'
-        }, RestTypes::POST, false, nil)
+        restclient_1 = RestClient.new(
+            uri: 'https://stackoverflow.com/questions/2024805/ruby-send-json-request', 
+            headers: {
+                'Content-Type' => 'application/json'
+                }, 
+            rest_type: RestTypes::POST, 
+            ssl: false, 
+            params: nil
+            )
         assert_equal(restclient_1.getURI(), 'https://stackoverflow.com/questions/2024805/ruby-send-json-request')
 
-        restclient_2 = RestClient.new('https://stackoverflow.com/questions/2024805/ruby-send-json-request2', {
-            'Content-Type' => 'application/json'
-        }, RestTypes::POST, false, nil)
+        restclient_2 = RestClient.new(
+            uri: 'https://stackoverflow.com/questions/2024805/ruby-send-json-request2', 
+            headers: {
+                'Content-Type' => 'application/json'
+                }, 
+            rest_type: RestTypes::POST, 
+            ssl: false, 
+            params: nil
+            )
         assert_equal(restclient_2.getURI(), 'https://stackoverflow.com/questions/2024805/ruby-send-json-request2')
     end
 
     def test_get_port()
-        restclient = RestClient.new('https://stackoverflow.com/questions/2024805/ruby-send-json-request', {
-            'Content-Type' => 'application/json'
-        }, RestTypes::POST, false, nil)
+        restclient = RestClient.new(
+            uri: 'https://stackoverflow.com/questions/2024805/ruby-send-json-request', 
+            headers: {
+                'Content-Type' => 'application/json'
+                }, 
+            rest_type: RestTypes::POST, 
+            ssl: false, 
+            params: nil
+            )
         assert_equal(restclient.getPort(), 443)
     end
 
     def test_get_host()
-        restclient = RestClient.new('https://stackoverflow.com/questions/2024805/ruby-send-json-request', {
-            'Content-Type' => 'application/json'
-        }, RestTypes::POST, false, nil)
+        restclient = RestClient.new(
+            uri: 'https://stackoverflow.com/questions/2024805/ruby-send-json-request', 
+            headers: {
+                'Content-Type' => 'application/json'
+                }, 
+            rest_type: RestTypes::POST, 
+            ssl: false, 
+            params: nil
+            )
         assert_equal(restclient.getHost(), 'stackoverflow.com')
     end
 
     def test_set_body()
-        restclient = RestClient.new('https://stackoverflow.com/questions/2024805/ruby-send-json-request', {
-            'Content-Type' => 'application/json'
-        }, RestTypes::POST, false, nil)
+        restclient = RestClient.new(
+            uri: 'https://stackoverflow.com/questions/2024805/ruby-send-json-request', 
+            headers: {
+                'Content-Type' => 'application/json'
+                }, 
+            rest_type: RestTypes::POST, 
+            ssl: false, 
+            params: nil
+            )
 
         restclient.setBody(
             {"action":"coreui_Repository","method":"update","data":[{"attributes":{"maven":{"versionPolicy":"RELEASE","layoutPolicy":"STRICT"},"storage":{"blobStoreName":"default","strictContentTypeValidation":true,"writePolicy":"ALLOW"}},"name":"maven-releases","format":"maven2","type":"hosted","url":"http://34.204.223.49:8080/repository/maven-releases/","online":true}],"type":"rpc","tid":90}.to_json
@@ -73,12 +127,18 @@ class TestRestClient < Test::Unit::TestCase
     end
 
     def test_get()
-        restclient = RestClient.new('https://api.travis-ci.com/builds', {
-            'Content-Type' => 'application/json',
-            'Travis-API-Version' => '3',
-            'Authorization' => "token #{ENV['TRAVIS_TOKEN']}"
-        }, RestTypes::GET, true, nil)
 
+        restclient = RestClient.new(
+            uri: 'https://api.travis-ci.com/builds', 
+            headers: {
+                'Content-Type' => 'application/json',
+                'Travis-API-Version' => '3',
+                'Authorization' => "token #{ENV['TRAVIS_TOKEN']}"
+            },
+            rest_type: RestTypes::GET, 
+            ssl: true, 
+            params: nil
+            )
         response = restclient.get()
 
         assert_not_nil(response)
@@ -86,12 +146,17 @@ class TestRestClient < Test::Unit::TestCase
     end
 
     def test_get2()
-        url = 'https://api.travis-ci.com/repo/AES-Outreach%2FForms-Application/builds'
-        restclient = RestClient.new(url, {
-            'Content-Type' => 'application/json',
-            'Travis-API-Version' => '3',
-            'Authorization' => "token #{ENV['TRAVIS_TOKEN']}"
-        }, RestTypes::GET, true, {'state' => 'started'})
+        restclient = RestClient.new(
+            uri: 'https://api.travis-ci.com/repo/AES-Outreach%2FForms-Application/builds', 
+            headers: {
+                'Content-Type' => 'application/json',
+                'Travis-API-Version' => '3',
+                'Authorization' => "token #{ENV['TRAVIS_TOKEN']}"
+            },
+            rest_type: RestTypes::GET, 
+            ssl: true, 
+            params:  {'state' => 'started'}
+            )
 
         response =  restclient.get()
 
@@ -104,13 +169,19 @@ class TestRestClient < Test::Unit::TestCase
     end
 
     def test_trigger_travis_build()
-        restclient = RestClient.new('https://api.travis-ci.com/repo/AES-Outreach%2FWebconsole-Branding/requests', {
-            'Content-Type' => 'application/json',
-            'Accept' => 'application/json',
-            'Travis-API-Version' => '3',
-            'Authorization' => "token #{ENV['TRAVIS_TOKEN']}"
-        }, RestTypes::POST, true, nil)
 
+        restclient = RestClient.new(
+            uri: 'https://api.travis-ci.com/repo/AES-Outreach%2FWebconsole-Branding/requests', 
+            headers: {
+                'Content-Type' => 'application/json',
+                'Accept' => 'application/json',
+                'Travis-API-Version' => '3',
+                'Authorization' => "token #{ENV['TRAVIS_TOKEN']}"
+            },
+            rest_type: RestTypes::POST, 
+            ssl: true, 
+            params:  nil
+            )
         restclient.setBody({
             "request": {
                 "message": "Trigger the start of the QA build process [ci skip]",

--- a/outreach_gem/tests/rest-client/unit-tests.rb
+++ b/outreach_gem/tests/rest-client/unit-tests.rb
@@ -254,7 +254,7 @@ class TestRestClient < Test::Unit::TestCase
         assert_equal("ssl cannot be empty", exception.message) 
     end
 
-    def test_params_can_be_nil() 
+    def test_params_can_be_ommited() 
         assert_nothing_raised do
             RestClient.new(
             :uri => 'https://stackoverflow.com/questions/2024805/ruby-send-json-request',
@@ -266,6 +266,7 @@ class TestRestClient < Test::Unit::TestCase
             )
         end
     end
+
 
     def test_other_order_initialization() 
         assert_nothing_raised do


### PR DESCRIPTION
## Purpose
The constructors of the OutreachUploadS3 and RestClient classes now use a hash in order to instantiate the object. This way we can scale the properties within the constructor without having to worry about nil values, similar to typescript.

## Acceptance Criteria
- [ ] The constructors of the OutreachUploadS3 and RestClient classes should use a hash as their input parameter instead of individual parameters 

## Screenshots
![c1](https://user-images.githubusercontent.com/33612255/59717265-a6979100-91e5-11e9-94cd-97a73097ba01.png)
![c2](https://user-images.githubusercontent.com/33612255/59717270-a7c8be00-91e5-11e9-9e38-8f3b37a24e44.png)
![c3](https://user-images.githubusercontent.com/33612255/59717924-ffb3f480-91e6-11e9-8118-018b555f681c.PNG)
![c4](https://user-images.githubusercontent.com/33612255/59717932-017db800-91e7-11e9-9267-0bbcc414e8b3.PNG)
